### PR TITLE
The is() function should also be able to match on a wildcard.

### DIFF
--- a/src/header-helpers.ts
+++ b/src/header-helpers.ts
@@ -12,6 +12,7 @@ import ResponseInterface from './response';
  * * application/json
  * * hal+json
  * * json
+ * * application/*
  */
 export function is(message: RequestInterface | ResponseInterface, type: string): boolean {
 
@@ -31,6 +32,11 @@ export function is(message: RequestInterface | ResponseInterface, type: string):
 
   if (subType === type) {
     // Matches hal+json
+    return true;
+  }
+
+  if (type === mainType + '/*') {
+    // matches application/*
     return true;
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -152,6 +152,7 @@ export abstract class Request<T = any> {
    * * application/json
    * * hal+json
    * * json
+   * * application/*
    */
   is(type: string): boolean {
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -80,6 +80,7 @@ export abstract class Response<T = any> {
    * * application/json
    * * hal+json
    * * json
+   * * application/*
    */
   is(type: string): boolean {
 

--- a/test/header-helpers.ts
+++ b/test/header-helpers.ts
@@ -28,6 +28,8 @@ describe('Header helpers', () => {
       ['application/json', 'hal+json', false],
       ['application/json', 'json', true],
       ['application/json', 'hal', false],
+      ['application/json', 'application/*', true],
+      ['application/json', 'image/*', false],
     ];
 
     for(const test of tests) {


### PR DESCRIPTION
e.g.:

A content-type of 'application/json' should match 'application/*'