### PR TITLE
Adding a links object on both the request and response.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -357,6 +357,12 @@
       "integrity": "sha512-RObYTpPMo0IY+ZksPtKHsXlYFRxsYIvUqd68e89Y7otDrXsjBy1VgMd53kxVV0JMsNlkCASjllFOlLlhxEv0iw==",
       "dev": true
     },
+    "@types/http-link-header": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.1.tgz",
+      "integrity": "sha512-5h+Pqs4EHoMkY/fLva7XsYmh9IVQghQ6uWWil1FGCNI0WqjhI4g20doYsbT4kJ/G3GkAlQca4AIc9OexdUnzkg==",
+      "dev": true
+    },
     "@types/keygrip": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.1.tgz",
@@ -1009,6 +1015,11 @@
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
+    },
+    "http-link-header": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.2.tgz",
+      "integrity": "sha512-z6YOZ8ZEnejkcCWlGZzYXNa6i+ZaTfiTg3WhlV/YvnNya3W/RbX1bMVUMTuCrg/DrtTCQxaFCkXCz4FtLpcebg=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/accepts": "^1.3.5",
     "@types/chai": "^4.2.7",
     "@types/co-body": "0.0.3",
+    "@types/http-link-header": "^1.0.1",
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.11",
     "@types/node-fetch": "^2.5.4",
@@ -57,6 +58,7 @@
   "dependencies": {
     "@curveball/http-errors": "^0.3.0",
     "accepts": "^1.3.7",
+    "http-link-header": "^1.0.2",
     "raw-body": "^2.4.1"
   },
   "engines": {

--- a/src/links.ts
+++ b/src/links.ts
@@ -1,0 +1,145 @@
+import LinkHeader from 'http-link-header';
+import { HeadersInterface } from './headers';
+
+export type Link = {
+  href: string,
+  rel: string,
+
+  position?: 'body' | 'header',
+
+  anchor?: string,
+  type?: string,
+  hreflang?: string,
+  media?: string,
+};
+
+export class LinkManager {
+
+  private headers: HeadersInterface;
+  private links: Map<string, Link[]>;
+
+  constructor(headers: HeadersInterface) {
+    this.headers = headers;
+    this.links = new Map();
+    this.syncFromHeaders();
+  }
+
+  get(rel: string): Link|null {
+
+    if (!this.links.has(rel)) {
+      return null;
+    }
+    return this.links.get(rel)![0];
+
+  }
+
+  getMany(rel: string): Link[] {
+
+    return this.links.get(rel) || [];
+
+  }
+
+  has(rel: string): boolean {
+
+    return this.links.has(rel);
+
+  }
+
+  delete(rel: string): void {
+
+    this.links.delete(rel);
+    this.syncToHeaders();
+
+  }
+
+  getAll(): Link[] {
+
+    const result: Link[] = [];
+    // A little bit of magic to merge all link arrays together
+    return result.concat(...this.links.values());
+
+  }
+
+  append(rel: string, href: string, attributes?: Partial<Link>): void;
+  append(link: Link): void;
+  append(arg1: string|Link, href?: string, attributes?: Partial<Link>): void {
+
+    let link: Link;
+    if (typeof arg1 === 'string') {
+      link = {
+        rel: arg1,
+        href: href!,
+        ...attributes
+      };
+    } else {
+      link = arg1;
+    }
+
+    if (this.links.has(link.rel)) {
+      this.links.get(link.rel)!.push(link);
+    } else {
+      this.links.set(link.rel, [link]);
+    }
+
+    if (link.position === 'header') {
+      this.setLinkHeader(link);
+    }
+
+  }
+
+  private syncToHeaders(): void {
+
+    this.headers.delete('Link');
+    for (const link of this.getAll()) {
+      if (link.position === 'header') {
+        this.setLinkHeader(link);
+      }
+    }
+
+  }
+
+  private syncFromHeaders(): void {
+
+    const lh = new LinkHeader();
+    const linkHeader = this.headers.get('Link');
+    if (!linkHeader) { return; }
+    lh.parse(linkHeader);
+
+    for (const link of lh.refs) {
+
+      const { uri, ...linkInfo} = link;
+      const realLink: Link = {
+        href: uri,
+        position: 'header',
+        ...linkInfo
+      };
+
+      if (this.links.has(link.rel)) {
+        this.links.get(link.rel)!.push(realLink);
+      } else {
+        this.links.set(link.rel, [realLink]);
+      }
+
+    }
+
+  }
+
+  private setLinkHeader(link: Link): void {
+
+    const lh = new LinkHeader();
+
+    const {rel, href, ...linkInfo} = link;
+
+    lh.set({
+      uri: href,
+      rel: rel,
+      ...(linkInfo as any),
+    });
+    this.headers.append(
+      'Link',
+      lh.toString()
+    );
+
+  }
+
+}

--- a/src/memory-request.ts
+++ b/src/memory-request.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'stream';
 import { Headers, HeadersInterface, HeadersObject } from './headers';
+import { LinkManager } from './links';
 import Request from './request';
 
 export class MemoryRequest<T> extends Request<T> {
@@ -29,6 +30,7 @@ export class MemoryRequest<T> extends Request<T> {
     // @ts-ignore: Typescript doesn't like null here because it might be
     // incompatible with T, but we're ignoring it as it's a good default.
     this.body = null;
+    this.links = new LinkManager(this.headers);
 
   }
 

--- a/src/memory-response.ts
+++ b/src/memory-response.ts
@@ -1,4 +1,5 @@
 import { Headers } from './headers';
+import { LinkManager } from './links';
 import Response from './response';
 
 export class MemoryResponse<T> extends Response<T> {
@@ -11,6 +12,7 @@ export class MemoryResponse<T> extends Response<T> {
     // @ts-ignore: Typescript doesn't like null here because it might be
     // incompatible with T, but we're ignoring it as it's a good default.
     this.body = null;
+    this.links = new LinkManager(this.headers);
 
   }
 

--- a/src/node/request.ts
+++ b/src/node/request.ts
@@ -1,6 +1,7 @@
 import rawBody from 'raw-body';
 import { Readable } from 'stream';
 import { Headers, HeadersInterface } from '../headers';
+import { LinkManager } from '../links';
 import Request from '../request';
 import { NodeHttpRequest } from './http-utils';
 
@@ -28,6 +29,7 @@ export class NodeRequest<T> extends Request<T> {
     this.inner = inner;
     // @ts-ignore ignoring that headers might be undefined
     this.headers = new Headers(this.inner.headers);
+    this.links = new LinkManager(this.headers);
 
   }
 

--- a/src/node/response.ts
+++ b/src/node/response.ts
@@ -3,6 +3,7 @@ import { promisify } from 'util';
 import { invokeMiddlewares, Middleware } from '../application';
 import Context from '../context';
 import { HeadersInterface, HeadersObject } from '../headers';
+import { LinkManager } from '../links';
 import MemoryRequest from '../memory-request';
 import MemoryResponse from '../memory-response';
 import Response from '../response';
@@ -28,6 +29,7 @@ export class NodeResponse<T> extends Response<T> {
     this.body = null;
     this.status = 404;
     this.explicitStatus = false;
+    this.links = new LinkManager(this.headers);
 
   }
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,6 +4,7 @@ import { Readable } from 'stream';
 import url from 'url';
 import { is, parsePrefer } from './header-helpers';
 import { HeadersInterface } from './headers';
+import { LinkManager } from './links';
 
 /**
  * This interface represents an incoming server request.
@@ -14,6 +15,11 @@ export abstract class Request<T = any> {
    * List of HTTP Headers
    */
   headers: HeadersInterface;
+
+  /**
+   * HTTP Links manager
+   */
+  links: LinkManager;
 
   /**
    * path-part of the request.

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,6 +1,7 @@
 import { Middleware } from './application';
 import { is } from './header-helpers';
 import { HeadersInterface, HeadersObject } from './headers';
+import { LinkManager } from './links';
 
 /**
  * This interface represents an incoming server request.
@@ -21,6 +22,11 @@ export abstract class Response<T = any> {
    * The response body.
    */
   body: T;
+
+  /**
+   * HTTP Links manager
+   */
+  links: LinkManager;
 
   /**
    * Returns the value of the Content-Type header, with any additional

--- a/test/node/push.ts
+++ b/test/node/push.ts
@@ -290,6 +290,9 @@ describe('NodeResponse http/2 push', () => {
     const response = new NodeResponse(<any> {
       stream: {
         pushAllowed: true
+      },
+      getHeader(key: string) {
+        return null;
       }
     });
 
@@ -317,6 +320,9 @@ describe('NodeResponse http/2 push', () => {
           callback(new Error('hi'));
         },
         pushAllowed: true
+      },
+      getHeader(key: string) {
+        return null;
       }
     });
 


### PR DESCRIPTION
This is kind of an experimental approach. Shouldn't merge this until it
had some more testing (and is fully covered with unittests).

The goal of this feature is to have a unified way to access Web Links
via a simple API, whether that's links in a HTTP Link header, or
embedded in a body.

If links are embedded in a body, middlewares should be written to
automatically read and/or write them.

Sample usage:

```typescript
const link = ctx.request.links.get('author');

ctx.response.links.set({
  rel: 'author',
  href: 'https://evertpot.com/',
  type: 'text/html',
  position: 'header', // or body
});
```

Right now I'm just looking for some feedback about this specific approach.