### PR TITLE
Use text/plain mimetype for errors that fall through

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -117,6 +117,7 @@ export default class Application extends EventEmitter {
         } else {
           res.statusCode = 500;
         }
+        res.setHeader('Content-Type', 'text/plain');
         res.end(
           // @ts-ignore
           'Uncaught exception. No middleware was defined to handle it. We got the following HTTP status: ' +


### PR DESCRIPTION
These errors only pop-up if there's no error-handling middleware
defined. Right now the default content-type is application/json, so this
will be a bit nicer.