### PR TITLE
Request bodies will be typed as 'unknown' by default.

### DIFF
--- a/src/base-context.ts
+++ b/src/base-context.ts
@@ -35,7 +35,7 @@ export default class BaseContext<ReqT = any, ResT = any> implements Context<ReqT
     [s: string]: any
   };
 
-  constructor(req: Request, res: Response) {
+  constructor(req: Request<ReqT>, res: Response<ResT>) {
 
     this.request = req;
     this.response = res;

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import Request from './request';
 import Response from './response';
 import WebSocket from 'ws';
 
-export interface Context<ReqT = any, ResT = any> {
+export interface Context<ReqT = unknown, ResT = any> {
 
   /**
    * HTTP Request
@@ -119,7 +119,7 @@ export interface Context<ReqT = any, ResT = any> {
  * This is the Context that will be passed in case a WebSocket request was
  * initiated.
  */
-export interface WsContext extends Context<any, any> {
+export interface WsContext extends Context<unknown, any> {
 
   /**
    * WebSocket object.

--- a/src/request.ts
+++ b/src/request.ts
@@ -9,7 +9,7 @@ import { Headers } from './headers';
 /**
  * This interface represents an incoming server request.
  */
-export abstract class Request<T = any> {
+export abstract class Request<T = unknown> {
 
   constructor(method: string, requestTarget: string) {
     this.method = method;

--- a/test/request.ts
+++ b/test/request.ts
@@ -19,9 +19,9 @@ class FakeRequest extends Request {
   async rawBody(encoding?: undefined, limit?: string): Promise<Buffer | string> {
 
     if (encoding) {
-      return this.body.toString(encoding);
+      return (this.body as any).toString(encoding);
     } else {
-      return this.body;
+      return (this.body as any);
     }
 
   }


### PR DESCRIPTION
This is a change from 'any' like it is in most other frameworks. This
change forces users that want to use the request body to either:

* Explicitly cast to any
* Validate

This is a BC break.