### PR TITLE
Support for a callback response body.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2020 Evert Pot
+Copyright (c) 2018-2021 Evert Pot
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -447,9 +447,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
-      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg=="
+      "version": "12.19.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.12.tgz",
+      "integrity": "sha512-UwfL2uIU9arX/+/PRcIkT08/iBadGN2z6ExOROA2Dh5mAuWTBj6iJbQX4nekiV5H8cTrEG569LeX+HRco9Cbxw=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/chai": "^4.2.14",
     "@types/co-body": "^5.1.0",
     "@types/mocha": "^8.0.4",
-    "@types/node": "^12.19.8",
+    "@types/node": "^12.19.12",
     "@types/node-fetch": "^2.5.7",
     "@types/sinon": "^9.0.9",
     "@typescript-eslint/eslint-plugin": "^4.9.0",

--- a/src/base-context.ts
+++ b/src/base-context.ts
@@ -35,7 +35,7 @@ export default class BaseContext<ReqT = any, ResT = any> implements Context<ReqT
     [s: string]: any
   };
 
-  constructor(req: Request, res: Response) {
+  constructor(req: Request<ReqT>, res: Response<ResT>) {
 
     this.request = req;
     this.response = res;

--- a/src/memory-request.ts
+++ b/src/memory-request.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream';
 import { Headers, HeadersInterface, HeadersObject } from './headers';
-import Request from './request';
+import { Request, Encoding } from './request';
 
 export class MemoryRequest<T> extends Request<T> {
 
@@ -50,9 +50,9 @@ export class MemoryRequest<T> extends Request<T> {
    * You can only call this function once. Most likely you'll want a single
    * middleware that calls this function and then sets `body`.
    */
-  rawBody(encoding?: string, limit?: string): Promise<string>;
+  rawBody(encoding?: Encoding, limit?: string): Promise<string>;
   rawBody(encoding?: undefined, limit?: string): Promise<Buffer>;
-  async rawBody(encoding?: undefined|string, limit?: string): Promise<Buffer|string> {
+  async rawBody(encoding?: undefined|Encoding, limit?: string): Promise<Buffer|string> {
 
     return this.getBody(encoding);
 
@@ -72,7 +72,7 @@ export class MemoryRequest<T> extends Request<T> {
 
   }
 
-  private getBody(encoding?: string) {
+  private getBody(encoding?: Encoding) {
 
     if (!this.originalBody) {
       // Memoizing the null case

--- a/src/memory-response.ts
+++ b/src/memory-response.ts
@@ -1,7 +1,7 @@
 import { Headers } from './headers';
-import Response from './response';
+import { Response, Body } from './response';
 
-export class MemoryResponse<T> extends Response<T> {
+export class MemoryResponse<T = Body> extends Response<T> {
 
   constructor() {
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -6,6 +6,8 @@ import { is, parsePrefer } from './header-helpers';
 import { HeadersInterface } from './headers';
 import { Headers } from './headers';
 
+export type Encoding = 'utf-8' | 'ascii' | 'hex';
+
 /**
  * This interface represents an incoming server request.
  */
@@ -89,7 +91,7 @@ export abstract class Request<T = any> {
    * You can only call this function once. Most likely you'll want a single
    * middleware that calls this function and then sets `body`.
    */
-  abstract rawBody(encoding: string, limit?: string): Promise<string>;
+  abstract rawBody(encoding: Encoding, limit?: string): Promise<string>;
   abstract rawBody(encoding?: undefined, limit?: string): Promise<Buffer>;
 
   /**

--- a/src/response.ts
+++ b/src/response.ts
@@ -2,11 +2,21 @@ import { Middleware } from './application';
 import { is } from './header-helpers';
 import { HeadersInterface, HeadersObject } from './headers';
 import { Headers } from './headers';
+import { Readable, Writable } from 'stream';
+
+export type Body =
+  Buffer |
+  Record<string, any> |
+  string |
+  null |
+  Readable |
+  ((writeable: Writable) => void);
+
 
 /**
  * This interface represents an incoming server request.
  */
-export abstract class Response<T = any> {
+export abstract class Response<T = Body> {
 
   constructor() {
 


### PR DESCRIPTION
This allows a user to set the body as such:

    ctx.response.body = (writable) => {
       writable.send('hello world!');
       writable.end();
     };

This makes it easy to deal with streams.

Fixes #165

cc @imdmitrykravchenko