### PR TITLE
Allow websockets to listen on the same port as the main HTTP server.

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -41,7 +41,7 @@ export interface Context<ReqT = unknown, ResT = any> {
    *
    * Shortcut for request.method
    */
-   method: string;
+  method: string;
 
   /**
    * This object contains parsed query string parameters.

--- a/test/websocket.ts
+++ b/test/websocket.ts
@@ -5,7 +5,38 @@ import { expect } from 'chai';
 
 describe('Websocket support', () => {
 
-  it('should start a websocket server', () => {
+  it('should automatically handle Websockets', () => {
+
+    const app = new Application();
+    app.use( ctx => {
+
+      if (!ctx.webSocket) {
+        throw new UpgradeRequired('Websocket is a must');
+      }
+
+      ctx.webSocket.send('Hello');
+
+
+    });
+    const wss = app.listen(57001);
+
+    return new Promise<void>(res => {
+      const ws = new WebSocket('ws://localhost:57001');
+      ws.on('message', (msg) => {
+
+        expect(msg).to.equal('Hello');
+        ws.close();
+        wss.close();
+        res();
+
+      });
+
+    });
+
+
+  });
+
+  it('Should let users open a websocket-only port with listenWs', () => {
 
     const app = new Application();
     app.use( ctx => {
@@ -35,6 +66,7 @@ describe('Websocket support', () => {
 
 
   });
+
 
   it('should start a websocket server with a hostname', () => {
 


### PR DESCRIPTION
Fixes #159