### PR TITLE
Support for fetch request and response objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@curveball/core",
-  "version": "0.19.0",
+  "version": "0.20.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@curveball/core",
-      "version": "0.19.0",
+      "version": "0.20.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@curveball/http-errors": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curveball/core",
-  "version": "0.19.0",
+  "version": "0.20.0-alpha.0",
   "description": "Curveball is a framework writting in Typescript for Node.js",
   "main": "dist/index.js",
   "scripts": {

--- a/src/fetch-util.ts
+++ b/src/fetch-util.ts
@@ -1,0 +1,86 @@
+import { MemoryRequest as CurveballRequest } from './memory-request';
+import { Response as CurveballResponse } from './response';
+import { Headers as CurveballHeaders } from './headers';
+import { PassThrough, Readable, Writable } from 'stream';
+
+export async function fetchRequestToCurveballRequest(request: Request): Promise<CurveballRequest<unknown>> {
+
+  const headers = new CurveballHeaders();
+  // @ts-expect-error apparently our types don't have an 'entries' on headers, but it's there!
+  for(const [key, value] of request.headers.entries()) {
+    headers.append(key, value);
+  }
+
+  const url = new URL(request.url);
+
+  let relativeUrl = url.pathname;
+  if (url.search) relativeUrl += '?' + url.search;
+
+  if (!headers.has('host')) headers.set('host', url.host);
+
+  return new CurveballRequest(
+    request.method,
+    relativeUrl,
+    headers,
+    await request.arrayBuffer()
+  );
+}
+
+export async function curveballResponseToFetchResponse(response: CurveballResponse): Promise<Response> {
+
+  const headers = new Headers();
+  for(const [key, value] of Object.entries(response.headers.getAll())) {
+    if (Array.isArray(value)) {
+      headers.set(key, value.join(','));
+    } else {
+      headers.set(key, ''+value);
+    }
+  }
+
+  return new Response(await convertCurveballBody(response.body), {
+    status: response.status,
+    headers,
+  });
+
+}
+
+async function convertCurveballBody(body: null | string | Buffer | Readable | Record<string, any> | ((outStream: Writable) => void)): Promise<BodyInit> {
+
+  if (body===null) {
+    return '';
+  }
+  if (typeof body === 'string') {
+    return body;
+  }
+  if (body instanceof Buffer) {
+    return body;
+  }
+  if (body instanceof Readable) {
+    return readStream(body);
+  }
+  if (typeof body === 'object') {
+    return JSON.stringify(body);
+  }
+  if (typeof body === 'function') {
+    const passThrough = new PassThrough();
+    body(passThrough);
+    return readStream(passThrough);
+  }
+  throw new TypeError('Unsupported type for body: ' + typeof body);
+
+}
+
+
+function readStream(stream: Readable): Promise<Buffer> {
+
+  return new Promise < Buffer > ((res, rej) => {
+
+    const buffer = Array < any > ();
+
+    stream.on('data', chunk => buffer.push(chunk));
+    stream.on('end', () => res(Buffer.concat(buffer)));
+    stream.on('error', err => rej(err));
+
+  });
+
+}

--- a/src/node/http-utils.ts
+++ b/src/node/http-utils.ts
@@ -2,6 +2,9 @@ import * as http from 'http';
 import * as http2 from 'http2';
 import { Readable, Writable } from 'stream';
 import { Body } from '../response';
+import { Context } from '../context';
+import { NodeRequest as CurveballNodeRequest } from './request';
+import { NodeResponse as CurveballNodeResponse } from './response';
 
 /**
  * A node.js Http request
@@ -42,6 +45,16 @@ export function sendBody(res: NodeHttpResponse | http2.Http2Stream, body: Body):
   }
 
 }
+
+/**
+ * This function takes the request and response objects from a Node http,
+ * https or http2 server and returns a curveball compatible Context.
+ */
+export function createContextFromNode(req: NodeHttpRequest, res: NodeHttpResponse) {
+  const context = new Context(new CurveballNodeRequest(req), new CurveballNodeResponse(res));
+  return context;
+}
+
 
 /**
  * The HttpCallback is the function that is passed as a request listener to


### PR DESCRIPTION
This allows users to use the browser-native Request and Response types from the fetch standard with Curveball.

This can be useful to simulate HTTP requests in a test suite without actually having to go over the network.